### PR TITLE
fix: Download TLS certificate upfront when connecting to a courier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3213,6 +3213,14 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "check-ip": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/check-ip/-/check-ip-1.1.1.tgz",
+      "integrity": "sha1-dycO+qaaeFP+w3CfFDA2qOIOfqY=",
+      "requires": {
+        "ip-range-check": "^0.0.2"
+      }
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -5642,11 +5650,24 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "ip-range-check": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.0.2.tgz",
+      "integrity": "sha1-YFyFloeqTxhGORjUYZDYs2maKTw=",
+      "requires": {
+        "ipaddr.js": "^1.0.1"
+      }
+    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
     "@relaycorp/relaynet-core": "^1.27.1",
+    "check-ip": "^1.1.1",
     "env-var": "^6.1.1",
     "grpc": "^1.24.2",
     "it-pipe": "^1.1.0",

--- a/src/lib/_test_utils.ts
+++ b/src/lib/_test_utils.ts
@@ -12,7 +12,7 @@ export function getMockContext(mockedObject: any): jest.MockContext<any, any> {
 // tslint:disable-next-line:readonly-array
 export function mockSpy<T, Y extends any[]>(
   spy: jest.MockInstance<T, Y>,
-  mockImplementation?: () => any,
+  mockImplementation?: (...args: readonly any[]) => any,
 ): jest.MockInstance<T, Y> {
   beforeEach(() => {
     spy.mockClear();

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -18,9 +18,13 @@ export class CogRPCError extends RelaynetError {}
 
 // tslint:disable-next-line:max-classes-per-file
 export class CogRPCClient {
+  public static init(_serverUrl: string): CogRPCClient {
+    throw new Error('asfdwaxcfas');
+  }
+
   protected readonly grpcClient: InstanceType<typeof CargoRelayClient>;
 
-  constructor(serverUrl: string) {
+  protected constructor(serverUrl: string) {
     this.grpcClient = new CargoRelayClient(serverUrl, this.createCredentials(serverUrl));
   }
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,8 +1,10 @@
 import { CargoDeliveryRequest, RelaynetError } from '@relaycorp/relaynet-core';
+import checkIp from 'check-ip';
 import { get as getEnvVar } from 'env-var';
 import * as grpc from 'grpc';
 import pipe from 'it-pipe';
 import * as toIterable from 'stream-to-it';
+import * as tls from 'tls';
 import uuid from 'uuid-random';
 
 import {
@@ -14,18 +16,21 @@ import {
 
 const DEADLINE_SECONDS = 3;
 
+const COURIER_GRPC_PORT = 21473;
+
 export class CogRPCError extends RelaynetError {}
 
 // tslint:disable-next-line:max-classes-per-file
 export class CogRPCClient {
-  public static init(_serverUrl: string): CogRPCClient {
-    throw new Error('asfdwaxcfas');
+  public static async init(serverUrl: string): Promise<CogRPCClient> {
+    const credentials = await createCredentials(serverUrl);
+    return new CogRPCClient(serverUrl, credentials);
   }
 
   protected readonly grpcClient: InstanceType<typeof CargoRelayClient>;
 
-  protected constructor(serverUrl: string) {
-    this.grpcClient = new CargoRelayClient(serverUrl, this.createCredentials(serverUrl));
+  protected constructor(serverUrl: string, credentials: grpc.ChannelCredentials) {
+    this.grpcClient = new CargoRelayClient(serverUrl, credentials);
   }
 
   public close(): void {
@@ -111,16 +116,53 @@ export class CogRPCClient {
       throw new CogRPCError(error, 'Unexpected error while collecting cargo');
     }
   }
+}
 
-  protected createCredentials(serverUrl: string): grpc.ChannelCredentials {
-    const serverUrlParts = new URL(serverUrl);
-    const useTls = serverUrlParts.protocol === 'https:';
-    const isTlsRequired = getEnvVar('COGRPC_REQUIRE_TLS').default('true').asBool();
-    if (!useTls && isTlsRequired) {
-      throw new CogRPCError(`Cannot connect to ${serverUrl} because TLS is required`);
-    }
-    return useTls ? grpc.credentials.createSsl() : grpc.credentials.createInsecure();
+async function createCredentials(serverUrl: string): Promise<grpc.ChannelCredentials> {
+  const serverUrlParts = new URL(serverUrl);
+  const useTls = serverUrlParts.protocol === 'https:';
+  const isTlsRequired = getEnvVar('COGRPC_REQUIRE_TLS').default('true').asBool();
+  if (!useTls && isTlsRequired) {
+    throw new CogRPCError(`Cannot connect to ${serverUrl} because TLS is required`);
   }
+  return useTls
+    ? createTlsCredentials(serverUrlParts.hostname, serverUrlParts.port)
+    : grpc.credentials.createInsecure();
+}
+
+async function createTlsCredentials(host: string, port: string): Promise<grpc.ChannelCredentials> {
+  const ipInfo = checkIp(host);
+  if (!ipInfo.isValid || ipInfo.isPublicIp) {
+    // The host name is a domain name or a public IP address, so we should let the usual certificate
+    // validation take place.
+    return grpc.credentials.createSsl();
+  }
+
+  // The host is a private IP address so it's going to have a self-issued certificate. Due to a
+  // bug in grpc-node (https://github.com/grpc/grpc-node/issues/663), we can't simply instruct
+  // the client to accept self-issued certificates, so we have to download the TLS certificate
+  // from the server so we can pass it explicitly to the client.
+  const portNumber = port === '' ? COURIER_GRPC_PORT : parseInt(port, 10);
+  const certificatePem = await retrieveCertificatePem(host, portNumber);
+  return grpc.credentials.createSsl(certificatePem);
+}
+
+async function retrieveCertificatePem(host: string, port: number): Promise<Buffer> {
+  return new Promise((resolve) => {
+    const tlsSocket = tls.connect({ host, port, rejectUnauthorized: false }, () => {
+      const certificateDer: Buffer = tlsSocket.getPeerCertificate().raw;
+      tlsSocket.end();
+      return resolve(derCertificateToPem(certificateDer));
+    });
+  });
+}
+
+function derCertificateToPem(derBuffer: Buffer): Buffer {
+  const lines = derBuffer.toString('base64').match(/.{1,64}/g) as RegExpMatchArray;
+  const pemString = [`-----BEGIN CERTIFICATE-----`, ...lines, `-----END CERTIFICATE-----`].join(
+    '\n',
+  );
+  return Buffer.from(pemString);
 }
 
 function makeDeadline(): Date {

--- a/src/types/check-ip.d.ts
+++ b/src/types/check-ip.d.ts
@@ -1,7 +1,9 @@
 declare module 'check-ip' {
-  function checkIp(ip: string): {
-    readonly isValid: boolean,
-    readonly isPublicIp: boolean,
+  function checkIp(
+    ip: string,
+  ): {
+    readonly isValid: boolean;
+    readonly isPublicIp: boolean;
   };
   export = checkIp;
 }

--- a/src/types/check-ip.d.ts
+++ b/src/types/check-ip.d.ts
@@ -1,0 +1,7 @@
+declare module 'check-ip' {
+  function checkIp(ip: string): {
+    readonly isValid: boolean,
+    readonly isPublicIp: boolean,
+  };
+  export = checkIp;
+}


### PR DESCRIPTION
As a workaround for grpc/grpc-node#663

Fixes #22.