### PR TITLE
fix(deliverCargo): Cancel gRPC call when done to force server call closure

### DIFF
--- a/src/lib/_test_utils.ts
+++ b/src/lib/_test_utils.ts
@@ -40,6 +40,8 @@ export class MockGrpcBidiCall<Input, Output> extends Duplex {
 
   public readError?: Error;
 
+  public cancel = jest.fn();
+
   protected automaticallyEndReadStream = true;
 
   private readPosition = 0;

--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -327,6 +327,7 @@ describe('CogRPCClient', () => {
       await consumeAsyncIterable(client.deliverCargo(generateCargoRelays([stubRelay])));
 
       expect(mockCargoDeliveryCall.destroyed).toBeTrue();
+      expect(mockCargoDeliveryCall.cancel).toBeCalled();
     });
 
     test('Stream errors should be thrown', async () => {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -137,6 +137,9 @@ export class CogRPCClient {
         : new CogRPCError(error, 'Unexpected error while delivering cargo');
     } finally {
       sink.destroy();
+
+      // Work around https://github.com/grpc/grpc-node/issues/1238#issuecomment-901402063
+      call.cancel();
     }
   }
 


### PR DESCRIPTION
Works around https://github.com/grpc/grpc-node/issues/1238#issuecomment-901402063

Needed to make functional tests in https://github.com/relaycorp/relaynet-internet-gateway/pull/591 pass.
